### PR TITLE
Alternative to WYSIWYG iframes CT + validation

### DIFF
--- a/sites/default/themes/custom/know4pol_ec_europa/templates/node/node--external-page.tpl.php
+++ b/sites/default/themes/custom/know4pol_ec_europa/templates/node/node--external-page.tpl.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Template for the File content type.
+ */
+?>
+
+<iframe 
+  src="<?php print($variables['field_ext_url'][0]['url']); ?>" 
+  height="<?php print($variables['field_frame_height'][0]['value']); ?>" 
+  width="<?php print($variables['field_frame_width'][0]['value']); ?>" 
+  style="border:none;">
+</iframe>

--- a/sites/default/themes/custom/know4pol_ec_europa/templates/node/node.component.inc
+++ b/sites/default/themes/custom/know4pol_ec_europa/templates/node/node.component.inc
@@ -11,8 +11,14 @@
 function know4pol_ec_europa_preprocess_node(&$variables, $hook) {
   // For all content types.
   drupal_add_js('https://visualise.jrc.ec.europa.eu/javascripts/api/viz_v1.js', 'external');
-  if ($variables['type'] == 'file') {
-    _know4pol_ec_europa_preprocess_node__file($variables);
+  switch ($variables['type']) {
+    case 'file':
+      _know4pol_ec_europa_preprocess_node__file($variables);
+      break;
+
+    case 'external_page':
+      _know4pol_ec_europa_preprocess_node__external_page($variables);
+      break;
   }
 }
 
@@ -47,5 +53,22 @@ function _know4pol_ec_europa_preprocess_node__file(array &$variables) {
       );
       $node->translations->data[] = $t_node;
     }
+  }
+}
+
+/**
+ * Implements template_preprocess_node().
+ *
+ * @param array $variables
+ *   The original variables from the preprocess_node hook.
+ */
+function _know4pol_ec_europa_preprocess_node__external_page(array &$variables) {
+  // Default values if empty.
+  if (!isset($variables['field_frame_height'][0]['value'])) {
+    $variables['field_frame_height'] = [['value' => 350]];
+  }
+  // Default values if empty.
+  if (!isset($variables['field_frame_width'][0]['value'])) {
+    $variables['field_frame_width'] = [['value' => '100%']];
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36437299/51254947-864b7800-19a2-11e9-903c-499ca7e2e9b9.png)
Validation is REGEX: /^https:\/\/([a-z0-9]+\.)*europa\.eu\//